### PR TITLE
Add fleet-level AlloyDB Omni Grafana dashboard

### DIFF
--- a/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
+++ b/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
@@ -504,7 +504,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(alloydb_omni_node_cpu_mcpu{dbnamespace=\"$namespace\"},dbcluster)",
+          "query": "label_values(alloydb_omni_node_storage_limit_per_disk_byte{dbnamespace=\"$namespace\"},dbcluster)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,

--- a/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
+++ b/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
@@ -496,7 +496,7 @@
             "my-cluster-2"
           ]
         },
-        "definition": "label_values(alloydb_omni_node_cpu_mcpu{dbnamespace=\"$namespace\"},dbcluster)",
+        "definition": "label_values(alloydb_omni_node_storage_limit_per_disk_byte{dbnamespace=\"$namespace\"},dbcluster)",
         "includeAll": true,
         "label": "dbcluster",
         "multi": true,

--- a/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
+++ b/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
@@ -599,7 +599,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
+++ b/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
@@ -169,7 +169,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "100 *\nsum by (dbcluster) (\n  alloydb_omni_memory_used_byte{\n    dbnamespace=\"$namespace\",\n    dbcluster=~\"$dbcluster\",\n    dbnode=~\"$dbnode\"\n  }\n)\n/\nsum by (dbcluster) (\n  alloydb_omni_memory_limit_byte{\n    dbnamespace=\"$namespace\",\n    dbcluster=~\"$dbcluster\",\n    dbnode=~\"$dbnode\"\n  }\n)",
+          "expr": "100 *sum by (dbcluster) (alloydb_omni_memory_used_byte{dbnamespace=\"$namespace\", dbcluster=~\"$dbcluster\", dbnode=~\"$dbnode\" })/sum by (dbcluster) ( alloydb_omni_memory_limit_byte{    dbnamespace=\"$namespace\",   dbcluster=~\"$dbcluster\",   dbnode=~\"$dbnode\"  })",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
+++ b/experimental-tools/observability-stack/samples/grafana/fleet-alloydb-dashboard.json
@@ -1,0 +1,610 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (dbcluster) (\n  alloydb_omni_database_postgresql_backends{\n    dbnamespace=\"$namespace\",\n    dbcluster=~\"$dbcluster\"\n  }\n)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total connections per DB cluster",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 *\nsum by (dbcluster) (\n  alloydb_omni_memory_used_byte{\n    dbnamespace=\"$namespace\",\n    dbcluster=~\"$dbcluster\",\n    dbnode=~\"$dbnode\"\n  }\n)\n/\nsum by (dbcluster) (\n  alloydb_omni_memory_limit_byte{\n    dbnamespace=\"$namespace\",\n    dbcluster=~\"$dbcluster\",\n    dbnode=~\"$dbnode\"\n  }\n)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory utilization % per DB cluster",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk($k,\n  sum by (dbcluster) (\n    alloydb_omni_node_storage_usage_per_disk_byte{\n      dbnamespace=\"$namespace\",\n      dbcluster=~\"$dbcluster\"\n    }\n  ) / 1e9\n)",
+          "legendFormat": "{{dbcluster}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top-K DB clusters by total storage usage (GB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk($k,\n  100 *\n  rate(\n    alloydb_omni_node_cpu_usage_second_total{\n      dbnamespace=\"$namespace\",\n      dbcluster=~\"$dbcluster\",\n      dbnode=~\"$dbnode\"\n    }[5m]\n  )\n  /\n  (\n    alloydb_omni_node_cpu_mcpu{\n      dbnamespace=\"$namespace\",\n      dbcluster=~\"$dbcluster\",\n      dbnode=~\"$dbnode\"\n    } / 1000\n  )\n)",
+          "legendFormat": "{{dbcluster}} / {{dbnode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top-K DB nodes by CPU utilization (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "topk($k,\n  sum by (dbnode, dbcluster) (\n    alloydb_omni_node_storage_usage_per_disk_byte{\n      dbnamespace=\"$namespace\",\n      dbcluster=~\"$dbcluster\",\n      dbnode=~\"$dbnode\"\n    }\n  ) / 1e9\n)",
+          "legendFormat": "{{dbcluster}} / {{dbnode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top-K DB nodes by storage usage (GB)",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "schemaVersion": 42,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "alloydb-test",
+          "value": "alloydb-test"
+        },
+        "definition": "label_values(alloydb_omni_node_storage_limit_per_disk_byte,dbnamespace)",
+        "label": "namespace",
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(alloydb_omni_node_storage_limit_per_disk_byte,dbnamespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": [
+            "my-cluster",
+            "my-cluster-2"
+          ],
+          "value": [
+            "my-cluster",
+            "my-cluster-2"
+          ]
+        },
+        "definition": "label_values(alloydb_omni_node_cpu_mcpu{dbnamespace=\"$namespace\"},dbcluster)",
+        "includeAll": true,
+        "label": "dbcluster",
+        "multi": true,
+        "name": "dbcluster",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(alloydb_omni_node_cpu_mcpu{dbnamespace=\"$namespace\"},dbcluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "definition": "label_values(alloydb_omni_node_storage_limit_per_disk_byte{dbcluster=~\"$dbcluster\", dbnamespace=\"$namespace\"},dbnode)",
+        "includeAll": true,
+        "label": "dbnode",
+        "multi": true,
+        "name": "dbnode",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(alloydb_omni_node_storage_limit_per_disk_byte{dbcluster=~\"$dbcluster\", dbnamespace=\"$namespace\"},dbnode)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1",
+          "value": "1"
+        },
+        "name": "k",
+        "options": [
+          {
+            "selected": true,
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "selected": false,
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "selected": false,
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "selected": false,
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "selected": false,
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "selected": false,
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "selected": false,
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "selected": false,
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "selected": false,
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "selected": false,
+            "text": "10",
+            "value": "10"
+          }
+        ],
+        "query": "1,2,3,4,5,6,7,8,9,10",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "DBCluster Fleet Overview",
+  "uid": "ad8zp5s",
+  "version": 20
+}


### PR DESCRIPTION
Adds a sample Grafana dashboard JSON that can be imported directly as a starting point for AlloyDB Omni monitoring.
The dashboard provides a fleet-level overview with ready-to-use Prometheus queries, variables, and layouts.

Includes:
- Total connections per DB cluster
- Memory utilization (%) per DB cluster
- Top-K clusters by storage usage
- Top-K nodes by CPU utilization
- Top-K nodes by storage usage